### PR TITLE
Update query in getURLQuery in eventHandler.cfc

### DIFF
--- a/eventHandler.cfc
+++ b/eventHandler.cfc
@@ -200,6 +200,7 @@
 		<cfset var likeCi = getCiLike() />
 		<cfset var limitPre = "" />
 		<cfset var limitPost = "" />
+		<cfset var newline = Chr(13) & Chr(10) />
 
 		<cfswitch expression="#application.configBean.getDBType()#">
 			<cfcase value="mssql">
@@ -267,7 +268,15 @@
 			INNER JOIN
 				tcontent ON tclassextenddata.baseID = tcontent.contentHistID
 			WHERE
-				tclassextenddata.attributeValue #likeCi# <cfqueryparam cfsqltype="cf_sql_varchar" value="%#arguments.currentFilenameAdjusted#%">
+				(
+					tclassextenddata.attributeValue = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.currentFilenameAdjusted#">
+					OR
+					tclassextenddata.attributeValue #likeCi# <cfqueryparam cfsqltype="cf_sql_varchar" value="%#newline##arguments.currentFilenameAdjusted#">
+					OR
+					tclassextenddata.attributeValue #likeCi# <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.currentFilenameAdjusted##newline#%">
+					OR
+					tclassextenddata.attributeValue #likeCi# <cfqueryparam cfsqltype="cf_sql_varchar" value="%#newline##arguments.currentFilenameAdjusted##newline#%">
+				)
 			AND
 				tclassextendattributes.name = <cfqueryparam cfsqltype="cf_sql_varchar" value="alternateURL">
 			AND


### PR DESCRIPTION
We have a content with alternative URL with only a partial string of another content's alternative URL; for example:

page 1: has alternative URL "alturl"
page 2: has alternative URL "this-is-alturl"

; and, when navigating to /alturl/, it brings up the content of /this-is-alturl/.

This update should fix this issue.