### PR TITLE
Resolve Copy and Paste issue

### DIFF
--- a/eventHandler.cfc
+++ b/eventHandler.cfc
@@ -18,6 +18,9 @@
 
 	function onBeforeContentSave(event) {
 		var contentBean=event.getValue("contentBean");
+		if(request.action == 'core:carch.copy'){
+			contentBean.setAlternateUrl('');
+		}
 		checkForExistingFilename(contentBean);
 		checkForExistingAlternateURL(contentBean);
 	}


### PR DESCRIPTION
When copying and pasting content with alternate url values the paste
silently fails as the there can't be duplicate alternate url's.  This clears the alternate url value when a paste is occurring.